### PR TITLE
[FEATURE] Print additional charging info to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@
     brew install pyenv
     pyenv install 3.9.4
     pyenv global 3.9.4
-    pip3 install requests
-    pip3 install beautifulsoup4
+    pip3 install -r requirements.txt
 
 ## Ubuntu installation
 
     sudo apt install python3-pip
-    sudo pip3 install beautifulsoup4
+    sudo pip3 install -r requirements.txt
 
 ## Configuration
 

--- a/car.py
+++ b/car.py
@@ -67,9 +67,18 @@ class Car:
             charging_state = resp_json["charging"]["chargingStatus"]["value"]["chargingState"]
             current_soc = resp_json["charging"]["batteryStatus"]["value"]["currentSOC_pct"]
             battery_status_timestamp = resp_json["charging"]["batteryStatus"]["value"]["carCapturedTimestamp"]
+            remaining_mins = resp_json["charging"]["chargingStatus"]["value"]["remainingChargingTimeToComplete_min"]
+            r_hour, r_min = divmod(remaining_mins, 60)
+            charging_info = "{}, {} kW {}, {}h {}m remaining".format(
+                resp_json["charging"]["chargingStatus"]["value"]["chargeMode"],
+                resp_json["charging"]["chargingStatus"]["value"]["chargePower_kW"],
+                resp_json["charging"]["chargingStatus"]["value"]["chargeType"],
+                r_hour,
+                r_min
+            )
             logging.info("plug_connection_state    : %s", plug_connection_state)
-            logging.info("charging_state           : %s", charging_state)
-            logging.info("current_soc              : %s", current_soc)
+            logging.info("charging_state           : {} ({})".format(charging_state, charging_info))
+            logging.info("current_soc              : %s%%", current_soc)
             logging.info("battery_status_timestamp : %s", battery_status_timestamp)
 
         return resp_json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4==4.11.1
+requests==2.28.0


### PR DESCRIPTION
Sometimes if I plug in the charging cable immediately after opening the charging flap it will only charge at a very low reduced emergency kW rate. Printing the charging rate helps to catch this issue so I can plug out and in again to fix. The charging light does turn red near the charging port but I have usually walked away by then.