### PR TITLE
[BUGFIX] API jobs param no longer accepting 'all' as a value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,5 @@ config.ini
 tokens.json
 
 # Sensitive information
-output/*.json
+output/
 reports/*.csv

--- a/car.py
+++ b/car.py
@@ -50,7 +50,8 @@ class Car:
             "Authorization": "Bearer {}".format(self.tokens.get_access_token())
         }
         vin = config.get("car", "vin")
-        resp = self._get(api_url + "/vehicles/" + vin + "/selectivestatus?jobs=all", headers=headers)
+        jobs = config.get("api", "jobs")
+        resp = self._get(f"{api_url}/vehicles/{vin}/selectivestatus?jobs={jobs}", headers=headers)
         resp_json = resp.json()
 
         resp_json["requestTimestamp"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/config.ini.template
+++ b/config.ini.template
@@ -15,3 +15,6 @@ api = https://emea.bff.cariad.digital/vehicle/v1
 token_file = tokens.json
 vehicles_file = output/vehicles_%%Y%%m%%d_%%H%%M%%S.json
 vehicle_status_file = output/vehicle_status_%%Y%%m%%d_%%H%%M%%S.json
+
+[api]
+jobs = access,automation,batteryChargingCare,batterySupport,charging,chargingProfiles,climatisation,climatisationTimers,fuelStatus,measurements,readiness,userCapabilities,vehicleHealthInspection,vehicleHealthWarnings,vehicleLights


### PR DESCRIPTION
A list of job values was added to `config.ini.template`. Update your `config.ini` file accordingly. This list was based on the list of values returned for an ID.3 when the API supported the 'all' value. It does not represent the entire list of values available. There may be more values for other vehicle models.